### PR TITLE
Update FirstWhere.swift

### DIFF
--- a/Sources/Parsing/Parsers/FirstWhere.swift
+++ b/Sources/Parsing/Parsers/FirstWhere.swift
@@ -11,10 +11,11 @@ where
   }
 
   @inlinable
-  public func parse(_ input: inout Input) -> Input.Element? {
-    guard let first = input.first, self.predicate(first) else { return nil }
+  public func parse(_ input: inout Input) -> Input? {
+      let firstOfCollection = input.prefix(1)
+      guard let firstElement = input.first, self.predicate(firstElement) else { return nil }
     input.removeFirst()
-    return first
+      return firstOfCollection
   }
 }
 


### PR DESCRIPTION
Dear all,

I have been trying to use FirstWhere with Substring.UTF8View. I find it not very useful that FirstWhere returns a Collection.Element - in this case a Substring.UTF8View.Element. I did not find a way to cast this Element back to Substring.UTF8View. It seems to me that the only way to use the Substring.UTF8View.Element is to create a new String.

Assuming this is correct, I wondered if it would not be easier if the parser would return Substring.UTF8View as lot of others parser do.

In my fork you see an implementation proposal.

Thank you very much for the great library and the great video series!
Morstin
